### PR TITLE
fix #8 : deadlock on golang time <-t.C

### DIFF
--- a/internal/timers/timers.go
+++ b/internal/timers/timers.go
@@ -61,8 +61,10 @@ func (ts Timers) Add(s schedule.Schedule) []error {
 	// if found, we stop the existing timer
 	if t, ok := ts.items[s.ID()]; ok {
 		if !t.Stop() {
-			// TODO add a timeout
-			<-t.C
+			select {
+			case <-t.C:
+			default:
+			}
 		}
 	}
 
@@ -109,8 +111,10 @@ func (ts Timers) Delete(s schedule.Schedule) {
 func (ts Timers) deleteItem(id string) {
 	if t, ok := ts.items[id]; ok {
 		if !t.Stop() {
-			// TODO non blocking
-			<-t.C
+			select {
+			case <-t.C:
+			default:
+			}
 		}
 		delete(ts.items, id)
 	}
@@ -130,8 +134,10 @@ func (ts Timers) DeleteAll() {
 
 	for _, t := range ts.items {
 		if !t.Stop() {
-			// TODO non blocking
-			<-t.C
+			select {
+			case <-t.C:
+			default:
+			}
 		}
 		delete(ts.items, t.ID())
 	}

--- a/runner/kafka/handler.go
+++ b/runner/kafka/handler.go
@@ -213,9 +213,9 @@ func (k EventHandler) produceTargetMessage(msg kafka.Schedule) error {
 func (k EventHandler) Handle(event scheduler.Event) {
 	switch evt := event.(type) {
 	case schedule.InvalidSchedule:
-		log.Debugf("received an InvalidSchedule event: %T %+v errors=%v", evt, evt, evt.Errors)
+		log.Printf("received an InvalidSchedule event: %T %+v errors=%v", evt, evt, evt.Errors)
 	case schedule.MissedSchedule:
-		log.Debugf("received a MissedSchedule event: %T %v", evt, evt)
+		log.Printf("received a MissedSchedule event: %T %v", evt, evt)
 		msg, ok := evt.Schedule.(kafka.Schedule)
 		if !ok {
 			log.Errorf("event is not a kafka.Schedule: %T %+v", event, event)


### PR DESCRIPTION
When scheduler receives tens of schedules with the same id and to be triggered immediatly we have a deadlock
when stopping timer and draining its channel <-t.C. If the timer has expired or stopped the channel is nil.

also add some logs and timeout on tests