### PR TITLE
Added retry feature to clientlib and a backoff strategy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,6 @@ linters:
     - golint
     - gomnd
     - goprintffuncname
-    - gosec
     - gosimple
     - govet
     - ineffassign
@@ -108,6 +107,13 @@ linters:
   # - godot
   # - godox
   # - goerr113
+
+  # Following rule is disabled because of:
+  # retry/strategy_backoff.go:60:10: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
+  # durf = rand.Float64()*(durf-minf) + minf
+  # It cannot be satisfied because crypto/rand does not expose a method to random a float number...
+  # - gosec
+
   # - maligned
   # - nestif
   # - prealloc

--- a/clientlib/README.md
+++ b/clientlib/README.md
@@ -72,3 +72,97 @@ func main() {
     producer.Close()
 }
 ```
+
+## Schedule a message to be retried
+
+A Kafka message can also be scheduled as a retry object by applying a retry strategy. To do so, you can use the following `ScheduleRetry` function:
+
+```go
+msg := &kafka.Message{}
+
+retryConfig := retry.NewConfig() // No strategy specified, will use the default one
+result, err := clientlib.ScheduleRetry(msg, "schedule-id", "scheduler_topic", retryConfig)
+
+// ...
+```
+
+Default strategy applied is a backoff exponential strategy with:
+* Minimum retry value: 5 seconds
+* Maximum retry value: 1 hour
+* Factor: 2 (5 seconds, 10 seconds, 20 seconds, 40 seconds, ...)
+* Maximum retry attempt: 50
+
+A custom backoff strategy rule can be applied by using the following full example:
+
+```go
+package name
+
+import (
+    "github.com/etf1/kafka-message-scheduler/clientlib/retry"
+)
+
+func main() {
+    targetTopic := "target-topic"
+
+    msg := kafka.Message{
+        Key: []byte("video1"),
+        Timestamp:     time.Now(),
+        TimestampType: kafka.TimestampCreateTime,
+        Value:         []byte("some value"),
+        TopicPartition: kafka.TopicPartition{
+            Topic: &targetTopic,
+        },
+    }
+
+    retryConfig := retry.NewConfig(
+        retry.WithMaxAttempt(20),
+        retry.WithStrategy(&retry.Backoff{
+            Min: 10 * time.Second,
+            Max: 24 * time.Hour,
+            Factor: 4,
+        }),
+    )
+
+    schedulerMessage, err := clientlib.ScheduleRetry(&msg, "video1-schedule-online", "scheduler-topic", retryConfig)
+    if err != nil {
+        if err == ErrMaxAttemptReached {
+            log.Print("message have been retried maximum number of time, sending to dead queue now...")
+        } else {
+            log.Printf("unexpected error: %v", err)
+        }
+    }
+
+    producer, err := kafka.NewProducer(&kafka.ConfigMap{
+        "bootstrap.servers": "localhost:9092",
+    })
+    if err != nil {
+        log.Printf("error while initializing producer: %v", err)
+    }
+
+    producer.Produce(schedulerMessage, nil)    
+    producer.Close()
+}
+```
+
+### Define a custom retry strategy
+
+You can define your own strategy by implementing the following interface (defined in the `retry` package):
+
+```go
+type Strategy interface {
+	DurationForAttempt(attempt int) time.Duration
+	Reset()
+}
+```
+
+
+### Check if a message have been retried
+
+You can also use this function to know if a message have already been retried at least once:
+
+```go
+msg := &kafka.Message{}
+if clientlib.IsRetriedMessage(msg) {
+    // Do something
+}
+```

--- a/clientlib/clientlib.go
+++ b/clientlib/clientlib.go
@@ -1,21 +1,62 @@
 package clientlib
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/etf1/kafka-message-scheduler/clientlib/retry"
 )
 
 const (
-	Epoch       = "scheduler-epoch"
-	TargetTopic = "scheduler-target-topic"
-	TargetKey   = "scheduler-target-key"
+	// HeaderEpoch represents the epoch when the message have to be triggered.
+	HeaderEpoch = "scheduler-epoch"
+
+	// HeaderTargetTopic represents the target topic where the message will be triggered.
+	HeaderTargetTopic = "scheduler-target-topic"
+
+	// HeaderTargetKey represents the target key of the message that will be triggered.
+	HeaderTargetKey = "scheduler-target-key"
+
+	// HeaderRetryAttempt is the header key used in Kafka message to identify the retry attempt counter.
+	HeaderRetryAttempt = "retry-attempt"
+
+	// HeaderRetryOriginalTimestamp is the header key used in Kafka message to identify the original Kafka
+	// message timestamp.
+	HeaderRetryOriginalTimestamp = "retry-original-timestamp"
+
 	// SchedulerKey contains the header name of the header containing the original schedule id
 	// This header is set when the message is produced by the scheduler in the target topic
 	SchedulerKey = "scheduler-key"
+)
+
+var (
+	// ErrNoSchedulerTopic is throwed when no scheduler topic is provided.
+	ErrNoSchedulerTopic = errors.New("invalid parameter: scheduler's topic empty")
+
+	// ErrNoValue is throwed when a Kafka message does not have any value.
+	ErrNoValue = errors.New("invalid parameter: invalid parameter: message nil or value is empty")
+
+	// ErrNoTopicAssociated is throwed when a Kafka message does not have a topic associated.
+	ErrNoTopicAssociated = errors.New("invalid parameter: topic nil or empty")
+
+	// ErrNoSchedulerID is throwed when no scheduler identifier is specified.
+	ErrNoSchedulerID = errors.New("invalid parameter: schedule ID empty")
+
+	// ErrNoRetryConfigProvided is throwed when a no retry configuration is provided.
+	ErrNoRetryConfigProvided = errors.New("no configuration retry provided, please specify one")
+
+	// ErrInvalidEpoch is throwed when provided epoch is invalid.
+	ErrInvalidEpoch = errors.New("invalid parameter: invalid epoch")
+
+	// ErrMaxAttemptReached is throwed when a retried message has been attempted the maximum number of times.
+	ErrMaxAttemptReached = errors.New("retry attempt reached max number of time")
+
+	// Now allows to specify a custom current time in tests.
+	Now = time.Now
 )
 
 // Schedule will create a schedule kafka message from a candidate message.
@@ -26,27 +67,23 @@ const (
 func Schedule(msg *kafka.Message, scheduleID string, epoch int64, schedulerTopic string) (*kafka.Message, error) {
 	// Invalid parameters
 	if msg == nil || len(msg.Value) == 0 {
-		return nil, fmt.Errorf("invalid parameter: message nil or value is empty")
+		return nil, ErrNoValue
 	}
 
 	if msg.TopicPartition.Topic == nil || *msg.TopicPartition.Topic == "" {
-		return nil, fmt.Errorf("invalid parameter: topic nil or empty")
+		return nil, ErrNoTopicAssociated
 	}
 
 	if schedulerTopic == "" {
-		return nil, fmt.Errorf("invalid parameter: scheduler's topic empty")
+		return nil, ErrNoSchedulerTopic
 	}
 
 	if scheduleID == "" {
-		return nil, fmt.Errorf("invalid parameter: schedule ID empty")
+		return nil, ErrNoSchedulerID
 	}
 
-	if epoch < time.Now().Unix() {
-		return nil, fmt.Errorf("invalid parameter: invalid epoch")
-	}
-
-	bytes := func(i string) []byte {
-		return []byte(i)
+	if epoch < Now().Unix() {
+		return nil, ErrInvalidEpoch
 	}
 
 	headers := []kafka.Header{}
@@ -60,21 +97,21 @@ func Schedule(msg *kafka.Message, scheduleID string, epoch int64, schedulerTopic
 
 	headers = append(
 		headers, kafka.Header{
-			Key:   Epoch,
-			Value: bytes(strconv.FormatInt(epoch, 10)),
+			Key:   HeaderEpoch,
+			Value: []byte(strconv.FormatInt(epoch, 10)),
 		},
 		kafka.Header{
-			Key:   TargetTopic,
-			Value: bytes(*msg.TopicPartition.Topic),
+			Key:   HeaderTargetTopic,
+			Value: []byte(*msg.TopicPartition.Topic),
 		}, kafka.Header{
-			Key:   TargetKey,
+			Key:   HeaderTargetKey,
 			Value: msg.Key,
 		},
 	)
 
 	m := kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &schedulerTopic, Partition: kafka.PartitionAny},
-		Key:            bytes(scheduleID),
+		Key:            []byte(scheduleID),
 		Value:          msg.Value,
 		Headers:        headers,
 		Timestamp:      msg.Timestamp,
@@ -85,6 +122,24 @@ func Schedule(msg *kafka.Message, scheduleID string, epoch int64, schedulerTopic
 	return &m, nil
 }
 
+// ScheduleRetry retries a Kafka message by using the specified retry configuration.
+func ScheduleRetry(msg *kafka.Message, scheduleID, schedulerTopic string, config *retry.Config) (*kafka.Message, error) {
+	if config == nil {
+		return nil, ErrNoRetryConfigProvided
+	}
+
+	attempt := setHeaderRetryAttempt(msg)
+
+	if attempt > config.MaxAttempt {
+		return nil, ErrMaxAttemptReached
+	} else if attempt == 1 {
+		currentTimestamp := []byte(strconv.FormatInt(Now().Unix(), 10))
+		updateOrAddHeader(msg, HeaderRetryOriginalTimestamp, currentTimestamp)
+	}
+
+	return Schedule(msg, scheduleID, getNextEpoch(attempt, config.Strategy), schedulerTopic)
+}
+
 // DeleteSchedule creates a message for deleting a schedule. This message goal is to be produce by a kafka producer.
 func DeleteSchedule(scheduleID, schedulerTopic string) (*kafka.Message, error) {
 	// Invalid parameters
@@ -92,13 +147,9 @@ func DeleteSchedule(scheduleID, schedulerTopic string) (*kafka.Message, error) {
 		return nil, fmt.Errorf("invalid parameter")
 	}
 
-	bytes := func(i string) []byte {
-		return []byte(i)
-	}
-
 	m := kafka.Message{
 		TopicPartition: kafka.TopicPartition{Topic: &schedulerTopic, Partition: kafka.PartitionAny},
-		Key:            bytes(scheduleID),
+		Key:            []byte(scheduleID),
 		// tombstone message has nil Value
 		Value: nil,
 	}
@@ -106,17 +157,30 @@ func DeleteSchedule(scheduleID, schedulerTopic string) (*kafka.Message, error) {
 	return &m, nil
 }
 
-// IsSchedulerMessage tells if a message is coming from the scheduler
+// IsSchedulerMessage tells if a message is coming from the scheduler.
 func IsSchedulerMessage(msg *kafka.Message) bool {
-	if msg == nil {
-		return false
-	}
+	return getHeader(msg, SchedulerKey).Key == SchedulerKey
+}
 
-	for _, h := range msg.Headers {
-		if h.Key == SchedulerKey {
-			return true
+// IsRetriedMessage tells if a message has already been retried by the scheduler.
+func IsRetriedMessage(msg *kafka.Message) bool {
+	return getHeader(msg, HeaderRetryAttempt).Key == HeaderRetryAttempt
+}
+
+func setHeaderRetryAttempt(msg *kafka.Message) int {
+	attempt := 1
+	if value, hasValue := getHeaderValue(msg, HeaderRetryAttempt); hasValue {
+		if attemptValue, err := strconv.Atoi(value); err == nil {
+			attempt = attemptValue + 1
 		}
 	}
 
-	return false
+	updateOrAddHeader(msg, HeaderRetryAttempt, []byte(strconv.Itoa(attempt)))
+
+	return attempt
+}
+
+func getNextEpoch(attempt int, strategy retry.Strategy) int64 {
+	durationToAdd := strategy.DurationForAttempt(attempt)
+	return Now().Add(durationToAdd).Unix()
 }

--- a/clientlib/helper.go
+++ b/clientlib/helper.go
@@ -1,0 +1,42 @@
+package clientlib
+
+import (
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+func getHeader(message *kafka.Message, name string) kafka.Header {
+	if message == nil {
+		return kafka.Header{}
+	}
+
+	for _, header := range message.Headers {
+		if header.Key == name {
+			return header
+		}
+	}
+
+	return kafka.Header{}
+}
+
+func getHeaderValue(msg *kafka.Message, key string) (string, bool) {
+	for _, header := range msg.Headers {
+		if header.Key == key && len(header.Value) > 0 {
+			return string(header.Value), true
+		}
+	}
+	return "", false
+}
+
+func updateOrAddHeader(message *kafka.Message, key string, value []byte) {
+	for i, header := range message.Headers {
+		if header.Key == key {
+			message.Headers[i].Value = value
+			return
+		}
+	}
+
+	message.Headers = append(message.Headers, kafka.Header{
+		Key:   key,
+		Value: value,
+	})
+}

--- a/clientlib/retry/config.go
+++ b/clientlib/retry/config.go
@@ -1,0 +1,58 @@
+package retry
+
+import "time"
+
+var (
+	// DefaultMaxAttempt defines a default maximum retry attempt value.
+	DefaultMaxAttempt = 50
+
+	// DefaultStrategy defines a default strategy to be used in configuration
+	// if none specified.
+	DefaultStrategy = &Backoff{
+		Min:    5 * time.Second,
+		Max:    1 * time.Hour,
+		Factor: 2,
+	}
+)
+
+// ConfigOption is the type for custom config options
+type ConfigOption func(*Config)
+
+// Config provides configuration for retrying a message.
+type Config struct {
+	MaxAttempt int
+	Strategy   Strategy
+}
+
+// NewConfig allows to create a new retry configuration object.
+func NewConfig(options ...ConfigOption) *Config {
+	config := &Config{
+		MaxAttempt: DefaultMaxAttempt,
+		Strategy:   DefaultStrategy,
+	}
+
+	config.apply(options)
+
+	return config
+}
+
+func (c *Config) apply(options []ConfigOption) {
+	for _, option := range options {
+		option(c)
+	}
+}
+
+// WithMaxAttempt allows to specify a maximum retry attempt value after which
+// the message will not be retried anymore.
+func WithMaxAttempt(maxAttempt int) ConfigOption {
+	return func(c *Config) {
+		c.MaxAttempt = maxAttempt
+	}
+}
+
+// WithStrategy allows to specify a strategy to be used.
+func WithStrategy(strategy Strategy) ConfigOption {
+	return func(c *Config) {
+		c.Strategy = strategy
+	}
+}

--- a/clientlib/retry/config_test.go
+++ b/clientlib/retry/config_test.go
@@ -1,0 +1,58 @@
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+
+	checkValue(t, fmt.Sprintf("%T", config), "*retry.Config")
+	checkValue(t, config.MaxAttempt, DefaultMaxAttempt)
+	checkValue(t, config.Strategy, DefaultStrategy)
+}
+
+func TestNewConfig_option_with_max_attempt(t *testing.T) {
+	config := NewConfig(WithMaxAttempt(10))
+
+	checkValue(t, fmt.Sprintf("%T", config), "*retry.Config")
+	checkValue(t, config.MaxAttempt, 10)
+	checkValue(t, config.Strategy, DefaultStrategy)
+}
+
+func TestNewConfig_option_with_strategy(t *testing.T) {
+	customStrategy := &Backoff{
+		Factor: 2.5,
+		Min:    5 * time.Second,
+		Max:    30 * time.Second,
+	}
+
+	config := NewConfig(WithStrategy(customStrategy))
+
+	checkValue(t, fmt.Sprintf("%T", config), "*retry.Config")
+	checkValue(t, config.MaxAttempt, DefaultMaxAttempt)
+	checkValue(t, config.Strategy, customStrategy)
+}
+
+func TestNewConfig_option_all(t *testing.T) {
+	maxAttempt := 10
+	customStrategy := &Backoff{
+		Factor: 2.5,
+		Min:    5 * time.Second,
+		Max:    30 * time.Second,
+	}
+
+	config := NewConfig(WithMaxAttempt(maxAttempt), WithStrategy(customStrategy))
+
+	checkValue(t, fmt.Sprintf("%T", config), "*retry.Config")
+	checkValue(t, config.MaxAttempt, maxAttempt)
+	checkValue(t, config.Strategy, customStrategy)
+}
+
+func checkValue(t *testing.T, current, expected interface{}) {
+	if value := current; value != expected {
+		t.Errorf("wrong value for Topic property, have '%q', expected: '%q'", current, expected)
+	}
+}

--- a/clientlib/retry/strategy.go
+++ b/clientlib/retry/strategy.go
@@ -1,0 +1,10 @@
+package retry
+
+import "time"
+
+// Strategy represents a retry strategy.
+// It can be a backoff strategy or something else.
+type Strategy interface {
+	DurationForAttempt(attempt int) time.Duration
+	Reset()
+}

--- a/clientlib/retry/strategy_backoff.go
+++ b/clientlib/retry/strategy_backoff.go
@@ -1,0 +1,80 @@
+package retry
+
+import (
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	int64Overflow = 512
+	maxInt64      = float64(math.MaxInt64 - int64Overflow)
+)
+
+// Backoff is a time.Duration counter, starting at Min. After every call to
+// the Duration method the current timing is multiplied by Factor, but it
+// never exceeds Max.
+//
+// Backoff is not generally concurrent-safe, but the ForAttempt method can
+// be used concurrently.
+type Backoff struct {
+	attempt uint64
+	// Factor is the multiplying factor for each increment step
+	Factor float64
+	// Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	// Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+// DurationForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is concurrent-safe.
+func (b *Backoff) DurationForAttempt(attempt int) time.Duration {
+	// Zero-values are nonsensical, so we use
+	// them to apply defaults
+	min := b.Min
+	if min <= 0 {
+		min = 100 * time.Millisecond
+	}
+	max := b.Max
+	if max <= 0 {
+		max = 10 * time.Second
+	}
+	if min >= max {
+		// short-circuit
+		return max
+	}
+	factor := b.Factor
+	if factor <= 0 {
+		factor = 2
+	}
+	// calculate this duration
+	minf := float64(min)
+	durf := minf * math.Pow(factor, float64(attempt))
+	if b.Jitter {
+		durf = rand.Float64()*(durf-minf) + minf
+	}
+	// ensure float64 wont overflow int64
+	if durf > maxInt64 {
+		return max
+	}
+	dur := time.Duration(durf)
+	// keep within bounds
+	if dur < min {
+		return min
+	}
+	if dur > max {
+		return max
+	}
+	return dur
+}
+
+// Reset restarts the current attempt counter at zero.
+func (b *Backoff) Reset() {
+	atomic.StoreUint64(&b.attempt, 0)
+}

--- a/clientlib/retry/strategy_backoff_test.go
+++ b/clientlib/retry/strategy_backoff_test.go
@@ -1,0 +1,98 @@
+package retry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackOff(t *testing.T) {
+	testCases := []struct {
+		caseName         string
+		backoff          *Backoff
+		attempt          int
+		expectedDuration time.Duration
+	}{
+		{
+			caseName:         "Test case for factor 2, attempt #1",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 2},
+			attempt:          1,
+			expectedDuration: 20 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 2, attempt #2",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 2},
+			attempt:          2,
+			expectedDuration: 40 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 2, attempt #3",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 2},
+			attempt:          3,
+			expectedDuration: 80 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 2, attempt #4",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 2},
+			attempt:          4,
+			expectedDuration: 160 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 2, attempt #50 (more than 1 hour), should return 1 hour (max value)",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 2},
+			attempt:          20,
+			expectedDuration: 1 * time.Hour,
+		},
+		{
+			caseName:         "Test case for factor 1, attempt #1",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 1},
+			attempt:          1,
+			expectedDuration: 10 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 1, attempt #2",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 1},
+			attempt:          2,
+			expectedDuration: 10 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 1.5, attempt #1",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 1.5},
+			attempt:          1,
+			expectedDuration: 15 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 1.5, attempt #2",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 1.5},
+			attempt:          2,
+			expectedDuration: 22500 * time.Millisecond,
+		},
+		{
+			caseName:         "Test case for factor 1, attempt #2",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 1},
+			attempt:          2,
+			expectedDuration: 10 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 3, attempt #1",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 3},
+			attempt:          1,
+			expectedDuration: 30 * time.Second,
+		},
+		{
+			caseName:         "Test case for factor 3, attempt #2",
+			backoff:          &Backoff{Min: 10 * time.Second, Max: 1 * time.Hour, Factor: 3},
+			attempt:          2,
+			expectedDuration: 90 * time.Second,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			duration := testCase.backoff.DurationForAttempt(testCase.attempt)
+
+			if testCase.expectedDuration != duration {
+				t.Errorf("Wrong duration given (%v) for timestamp (%d)", duration, testCase.attempt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds support for `ScheduleRetry()` function that have to be used like the following example:

```go
msg := &kafka.Message{}

retryConfig := retry.NewConfig() // Default strategy will be applied

result, err := clientlib.ScheduleRetry(msg, "schedule-id", "scheduler_topic", retryConfig)
```

A specific backoff strategy rule can be applied by using:

```go
msg := &kafka.Message{}

retryConfig := retry.NewConfig(
    retry.WithMaxAttempt(200),
    retry.WithStrategy(&retry.Backoff{
        Min: 10 * time.Second,
        Max: 2 * time.Hour,
        Factor: 4,
   }),
)

result, err := clientlib.ScheduleRetry(msg, "schedule-id", "scheduler_topic", retryConfig)
```

Some new strategies could be added in the future, the interface to implement is:

```go
type Strategy interface {
	DurationForAttempt(attempt int) time.Duration
	Reset()
}
```

I also added a function to know if a message have already been retried:

```go
msg := &kafka.Message{}
if clientlib.IsRetriedMessage(msg) {
    // Do something
}
```