### PR TITLE
Change metrics http port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The scheduler can be configured with environment variables:
 | SCHEDULES_TOPICS  | schedules      | Topic list for incoming schedules separated by comma                                         |
 | SINCE_DELTA       | 0              | Number of days to go back for considering missed schedules (0:today, -1: yesterday, etc ...) |
 | GROUP_ID          | scheduler-cg   | Consumer group id for the scheduler consumer                                                 |
-| METRICS_HTTP_PORT | 8001           | HTTP port where prometheus metrics will be exposed (URI /metrics)                            |
+| METRICS_HTTP_ADDR | :8001          | HTTP address where prometheus metrics will be exposed (URI /metrics)                         |
 | HISTORY_TOPIC     | history        | Topic name where a copy of triggered schedules will be kept for auditing                     |
 
 # Usage

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,8 @@ func GraylogServer() string {
 	return getString("GRAYLOG_SERVER", "")
 }
 
-func MetricsHTTPPort() string {
-	return getString("METRICS_HTTP_PORT", "8001")
+func MetricsHTTPAddr() string {
+	return getString("METRICS_HTTP_ADDR", ":8001")
 }
 
 func BootstrapServers() string {

--- a/instrument/prometheus/prometheus.go
+++ b/instrument/prometheus/prometheus.go
@@ -2,7 +2,6 @@ package prometheus
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -23,17 +22,17 @@ type Collector struct {
 }
 
 // NewCollector create a prometheus collector
-func NewCollector(port string) Collector {
+func NewCollector(addr string) Collector {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/metrics", promhttp.Handler().ServeHTTP)
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%s", port),
+		Addr:    addr,
 		Handler: mux,
 	}
 
 	go func() {
-		log.Printf("prometheus metrics available on 0.0.0.0:%s/metrics", port)
+		log.Printf("prometheus metrics available on %s/metrics", addr)
 		if err := srv.ListenAndServe(); err != nil {
 			if err != http.ErrServerClosed {
 				log.Error(err)

--- a/runner/kafka/runner.go
+++ b/runner/kafka/runner.go
@@ -47,7 +47,7 @@ type Runner struct {
 }
 
 func DefaultCollector() prometheus.Collector {
-	return prometheus.NewCollector(config.MetricsHTTPPort())
+	return prometheus.NewCollector(config.MetricsHTTPAddr())
 }
 
 func DefaultConfig() Config {


### PR DESCRIPTION
Replace METRICS_HTTP_PORT by METRICS_HTTP_ADDR.
We can now define the binding address  (IP + Port).