### PR TITLE
Introduce an API server & liveness endpoints

### DIFF
--- a/apiserver/rest/helper_test.go
+++ b/apiserver/rest/helper_test.go
@@ -1,0 +1,37 @@
+package rest_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/etf1/kafka-message-scheduler/apiserver/rest"
+	hmapcoll "github.com/etf1/kafka-message-scheduler/internal/collector/hmap"
+	"github.com/etf1/kafka-message-scheduler/internal/store/hmap"
+	"github.com/etf1/kafka-message-scheduler/scheduler"
+)
+
+func newServer() (srv rest.Server, closeFunc func()) {
+	sch := scheduler.New(hmap.New(), hmapcoll.New())
+
+	sch.Start(scheduler.StartOfToday())
+
+	srv = rest.New(&sch)
+
+	return srv, func() {
+		sch.Close()
+	}
+}
+
+func executeRequest(router http.Handler, req *http.Request) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	return rr
+}
+
+func checkResponseCode(t *testing.T, expected, actual int) {
+	if expected != actual {
+		t.Errorf("Expected response code %d. Got %d\n", expected, actual)
+	}
+}

--- a/apiserver/rest/routes.go
+++ b/apiserver/rest/routes.go
@@ -1,0 +1,21 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func (s *Server) initRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.HandleFunc("/liveness", s.isAlive).Methods(http.MethodGet)
+	return router
+}
+
+func (s *Server) isAlive(w http.ResponseWriter, r *http.Request) {
+	if !s.IsAlive() {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/apiserver/rest/server.go
+++ b/apiserver/rest/server.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/etf1/kafka-message-scheduler/scheduler"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	defaultShutdownTimeout = 5 * time.Second
+)
+
+type Server struct {
+	*http.Server
+	*scheduler.Scheduler
+}
+
+func New(sch *scheduler.Scheduler) Server {
+	s := Server{}
+
+	s.Server = &http.Server{
+		Handler: s.initRouter(),
+	}
+
+	s.Scheduler = sch
+
+	return s
+}
+
+func (s *Server) Router() *mux.Router {
+	return s.Handler.(*mux.Router)
+}
+
+func (s *Server) Start(addr string) {
+	go func() {
+		log.Printf("starting rest api server on %s", addr)
+		defer log.Printf("rest api server stopped")
+
+		s.Addr = addr
+
+		if err := s.ListenAndServe(); err != nil {
+			if err != http.ErrServerClosed {
+				log.Error(err)
+			}
+		}
+	}()
+}
+
+func (s *Server) Stop() error {
+	defer log.Printf("rest api server shut down")
+	log.Printf("shutting down rest api server")
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+	defer cancel()
+
+	if err := s.Shutdown(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/apiserver/rest/server_test.go
+++ b/apiserver/rest/server_test.go
@@ -1,0 +1,21 @@
+package rest_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestServer_isalive(t *testing.T) {
+	s, closeFunc := newServer()
+	defer closeFunc()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFunc()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/liveness", nil)
+	response := executeRequest(s.Router(), req)
+
+	checkResponseCode(t, http.StatusOK, response.Code)
+}

--- a/cmd/kafka/init.go
+++ b/cmd/kafka/init.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/etf1/kafka-message-scheduler/config"
+	graylog "github.com/gemnasium/logrus-graylog-hook"
+	log "github.com/sirupsen/logrus"
+)
+
+func initLog() {
+	log.SetOutput(os.Stdout)
+	log.SetLevel(config.LogLevel())
+	formatter := &log.TextFormatter{
+		FullTimestamp: true,
+	}
+	log.SetFormatter(formatter)
+
+	if graylogServer := config.GraylogServer(); graylogServer != "" {
+		hook := graylog.NewGraylogHook(graylogServer, map[string]interface{}{"app": app, "version": version, "facility": app})
+		defer hook.Flush()
+
+		log.AddHook(hook)
+	}
+}
+
+func initPprof() func() {
+	timeout := 5 * time.Second
+	startchan := make(chan os.Signal, 1)
+	signal.Notify(startchan, syscall.SIGUSR1)
+
+	stopchan := make(chan os.Signal, 1)
+	signal.Notify(stopchan, syscall.SIGUSR2)
+
+	exitchan := make(chan bool)
+
+	var server *http.Server
+
+	shutdown := func() {
+		if server != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			log.Printf("shutting down pprof server")
+			log.Printf("%v", server.Shutdown(ctx))
+		}
+	}
+
+	closePprof := func() {
+		shutdown()
+		exitchan <- true
+	}
+
+	router := http.NewServeMux()
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	go func() {
+		defer log.Printf("pprof launcher exited")
+		for {
+			select {
+			case <-exitchan:
+				return
+			case <-stopchan:
+				shutdown()
+			case <-startchan:
+				server = &http.Server{
+					Addr:    ":6060",
+					Handler: router,
+				}
+				go func() {
+					log.Printf("starting http pprof server")
+					log.Println(server.ListenAndServe())
+					log.Printf("http server pprof shutted down")
+					server = nil
+				}()
+			}
+		}
+	}()
+
+	return closePprof
+}

--- a/cmd/kafka/main.go
+++ b/cmd/kafka/main.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"context"
-	"net/http"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	graylog "github.com/gemnasium/logrus-graylog-hook"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/etf1/kafka-message-scheduler/config"
 	runner "github.com/etf1/kafka-message-scheduler/runner/kafka"
 )
 
@@ -22,11 +16,12 @@ var (
 )
 
 func main() {
-	closePprof := initPprof()
-	initLog()
+	defer initPprof()
 
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	initLog()
 
 	kafkaRunner := runner.DefaultRunner()
 
@@ -51,82 +46,5 @@ loop:
 		}
 	}
 
-	closePprof()
-
 	log.Printf("exiting ...")
-}
-
-func initLog() {
-	log.SetOutput(os.Stdout)
-	log.SetLevel(config.LogLevel())
-	formatter := &log.TextFormatter{
-		FullTimestamp: true,
-	}
-	log.SetFormatter(formatter)
-
-	if graylogServer := config.GraylogServer(); graylogServer != "" {
-		hook := graylog.NewGraylogHook(graylogServer, map[string]interface{}{"app": app, "version": version, "facility": app})
-		defer hook.Flush()
-
-		log.AddHook(hook)
-	}
-}
-
-func initPprof() func() {
-	timeout := 5 * time.Second
-	startchan := make(chan os.Signal, 1)
-	signal.Notify(startchan, syscall.SIGUSR1)
-
-	stopchan := make(chan os.Signal, 1)
-	signal.Notify(stopchan, syscall.SIGUSR2)
-
-	exitchan := make(chan bool)
-
-	var server *http.Server
-
-	shutdown := func() {
-		if server != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			log.Printf("shutting down pprof server")
-			log.Printf("%v", server.Shutdown(ctx))
-		}
-	}
-
-	closePprof := func() {
-		shutdown()
-		exitchan <- true
-	}
-
-	router := http.NewServeMux()
-	router.HandleFunc("/debug/pprof/", pprof.Index)
-	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	go func() {
-		defer log.Printf("pprof launcher exited")
-		for {
-			select {
-			case <-exitchan:
-				return
-			case <-stopchan:
-				shutdown()
-			case <-startchan:
-				server = &http.Server{
-					Addr:    "localhost:6060",
-					Handler: router,
-				}
-				go func() {
-					log.Printf("starting http pprof server")
-					log.Println(server.ListenAndServe())
-					log.Printf("http server pprof shutted down")
-					server = nil
-				}()
-			}
-		}
-	}()
-
-	return closePprof
 }

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,10 @@ func MetricsHTTPAddr() string {
 	return getString("METRICS_HTTP_ADDR", ":8001")
 }
 
+func APIServerAddr() string {
+	return getString("API_SERVER_ADDR", ":8080")
+}
+
 func BootstrapServers() string {
 	return getString("BOOTSTRAP_SERVERS", "localhost:9092")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/confluentinc/confluent-kafka-go v1.5.2
 	github.com/gemnasium/logrus-graylog-hook v2.0.7+incompatible
+	github.com/gorilla/mux v1.7.3
 	github.com/prometheus/client_golang v1.8.0
 	github.com/sirupsen/logrus v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/instrument/prometheus/prometheus.go
+++ b/instrument/prometheus/prometheus.go
@@ -33,6 +33,8 @@ func NewCollector(addr string) Collector {
 
 	go func() {
 		log.Printf("prometheus metrics available on %s/metrics", addr)
+		defer log.Printf("prometheus metrics server stopped")
+
 		if err := srv.ListenAndServe(); err != nil {
 			if err != http.ErrServerClosed {
 				log.Error(err)

--- a/scheduler/helper.go
+++ b/scheduler/helper.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"time"
 
+	"github.com/etf1/kafka-message-scheduler/internal/schedule/simple"
 	"github.com/etf1/kafka-message-scheduler/schedule"
 )
 
@@ -35,4 +36,14 @@ func EndOfToday() int64 {
 func IsInRange(since time.Time, s schedule.Schedule) bool {
 	// typically, in range of the current day
 	return since.Unix() <= s.Epoch() && s.Epoch() <= EndOfToday()
+}
+
+const isAliveID string = "||is-alive||"
+
+func isAliveSchedule(d time.Duration) schedule.Schedule {
+	return simple.NewSchedule(isAliveID, time.Now().Add(d))
+}
+
+func isIsAliveSchedule(s schedule.Schedule) bool {
+	return s.ID() == isAliveID
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -790,21 +790,24 @@ loop:
 				epoch,
 			})
 		case isalive = <-aliveChan:
-		case <-time.After(5 * time.Second):
-			t.Logf("time out")
+		case <-time.After(7 * time.Second):
+			t.Logf("timeout")
 			break loop
 		}
 	}
 
-	// calling isalive should be silent for the user of the scheduler
+	// isalive probes should not be visible in the scheduler triggered events output channel
 	if len(result) != 0 {
 		t.Fatalf("unexpected event in the triggered channel")
 	}
 
-	// check also metric == 0
+	// metrics should not be added for isalive probes
+	if l := len(coll.GetAll()); l != 0 {
+		t.Fatalf("metrics should be 0, got %v", l)
+	}
 
 	if !isalive {
-		t.Fatalf("scheduler is not alive")
+		t.Fatalf("scheduler is not alive :(")
 	}
 }
 


### PR DESCRIPTION
Two things in this commit:
    1- introduce an API Server which is used for liveness endpoint and for future api endpoint
    2- implementation of a liveness endpoint for probing the scheduler internals

Why need a liveness ?

The liveness endpoint will try to send a schedule simulating a store event and it makes
sure that the event is triggered as expected, to check if there is no deadlock or an issue
in scheduler operation.

useful for kubernetes