### PR TITLE
Make simple-schedule public

### DIFF
--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -197,6 +197,7 @@ func FullMessage(topic string, key, value interface{}, epoch int64, targetTopic 
 		Headers:        headers,
 		Value:          toBytes(value),
 		Key:            toBytes(key),
+		Timestamp:      time.Now(),
 	}
 }
 

--- a/schedule/simple/simple_schedule.go
+++ b/schedule/simple/simple_schedule.go
@@ -1,6 +1,7 @@
 package simple
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -51,6 +52,14 @@ func NewSchedule(id, epoch interface{}, timestamp ...time.Time) schedule.Schedul
 		epoch:     iepoch,
 		timestamp: ts,
 	}
+}
+
+func (s Schedule) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	m["id"] = s.ID()
+	m["epoch"] = s.Epoch()
+	m["timestamp"] = s.Timestamp()
+	return json.Marshal(m)
 }
 
 func (s Schedule) ID() string {

--- a/scheduler/helper.go
+++ b/scheduler/helper.go
@@ -3,8 +3,8 @@ package scheduler
 import (
 	"time"
 
-	"github.com/etf1/kafka-message-scheduler/internal/schedule/simple"
 	"github.com/etf1/kafka-message-scheduler/schedule"
+	"github.com/etf1/kafka-message-scheduler/schedule/simple"
 )
 
 func StartOfToday() time.Time {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/etf1/kafka-message-scheduler/instrument"
 	hmapcoll "github.com/etf1/kafka-message-scheduler/internal/collector/hmap"
-	"github.com/etf1/kafka-message-scheduler/internal/schedule/simple"
 	"github.com/etf1/kafka-message-scheduler/internal/store/hmap"
 	"github.com/etf1/kafka-message-scheduler/schedule"
+	"github.com/etf1/kafka-message-scheduler/schedule/simple"
 	"github.com/etf1/kafka-message-scheduler/scheduler"
 )
 


### PR DESCRIPTION
Other projects need a way to represent a schedule in their tests and it will be a shame if
they have to copy paste this code.