### PR TITLE
Add /info and /schedules endpoints

### DIFF
--- a/apiserver/rest/helper_test.go
+++ b/apiserver/rest/helper_test.go
@@ -13,7 +13,6 @@ import (
 
 func newServer() (srv rest.Server, closeFunc func()) {
 	sch := scheduler.New(hmap.New(), hmapcoll.New())
-
 	sch.Start(scheduler.StartOfToday())
 
 	srv = rest.New(&sch)
@@ -32,6 +31,6 @@ func executeRequest(router http.Handler, req *http.Request) *httptest.ResponseRe
 
 func checkResponseCode(t *testing.T, expected, actual int) {
 	if expected != actual {
-		t.Errorf("Expected response code %d. Got %d\n", expected, actual)
+		t.Fatalf("unexpected response code %d, expected: %d", actual, expected)
 	}
 }

--- a/apiserver/rest/routes.go
+++ b/apiserver/rest/routes.go
@@ -1,14 +1,21 @@
 package rest
 
 import (
+	"encoding/json"
+	"net"
 	"net/http"
+	"os"
 
+	"github.com/etf1/kafka-message-scheduler/config"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 )
 
 func (s *Server) initRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.HandleFunc("/liveness", s.isAlive).Methods(http.MethodGet)
+	router.HandleFunc("/info", s.info).Methods(http.MethodGet)
+	router.HandleFunc("/schedules", s.schedules).Methods(http.MethodGet)
 	return router
 }
 
@@ -18,4 +25,108 @@ func (s *Server) isAlive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) schedules(w http.ResponseWriter, r *http.Request) {
+	list := s.Timers.GetAll()
+
+	if len(list) == 0 {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err := respondWithJSON(w, http.StatusOK, list)
+	if err != nil {
+		log.Errorf("unable to respond with json: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) info(w http.ResponseWriter, r *http.Request) {
+	host, err := os.Hostname()
+	if err != nil {
+		log.Errorf("cannot get hostname: %v", host)
+	}
+
+	ips := make([]net.IP, 0)
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	for _, i := range ifaces {
+		addrs, err2 := i.Addrs()
+		if err != nil {
+			log.Errorf("cannot get addresses from interface %v: %v", i, err2)
+			break
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			ips = append(ips, ip)
+		}
+	}
+
+	type kafka struct {
+		BootstrapServers string   `json:"bootstrap_servers"`
+		Topics           []string `json:"topics"`
+		HistoryTopic     string   `json:"history_topic"`
+	}
+	type info struct {
+		Host             string   `json:"hostname"`
+		Address          []net.IP `json:"address"`
+		APIServerAddress string   `json:"api_server_address"`
+		kafka            `json:"kafka"`
+	}
+
+	result := info{
+		Host:             host,
+		Address:          ips,
+		APIServerAddress: config.APIServerAddr(),
+		kafka: kafka{
+			BootstrapServers: config.BootstrapServers(),
+			Topics:           config.SchedulesTopics(),
+			HistoryTopic:     config.HistoryTopic(),
+		},
+	}
+
+	err = respondWithJSON(w, http.StatusOK, result)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+}
+
+func respondWithError(w http.ResponseWriter, code int, message string) {
+	err := respondWithJSON(w, code, map[string]string{"error": message})
+	if err != nil {
+		log.Errorf("cannot respond with error: %v", err)
+	}
+}
+
+func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) error {
+	if payload != nil {
+		response, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+
+		_, err = w.Write(response)
+		if err != nil {
+			log.Errorf("cannot write response: %v", err)
+		}
+	} else {
+		w.WriteHeader(code)
+	}
+
+	return nil
 }

--- a/apiserver/rest/server_test.go
+++ b/apiserver/rest/server_test.go
@@ -2,20 +2,141 @@ package rest_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/etf1/kafka-message-scheduler/config"
+	"github.com/etf1/kafka-message-scheduler/schedule/simple"
 )
 
+// Rule #1: scheduler should have an endpoint for checking it is still alive
 func TestServer_isalive(t *testing.T) {
 	s, closeFunc := newServer()
 	defer closeFunc()
 
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/liveness", nil)
 	response := executeRequest(s.Router(), req)
 
 	checkResponseCode(t, http.StatusOK, response.Code)
+}
+
+// Rule #2: scheduler should have an endpoint for retrieving general information on the scheduler setup
+func TestServer_info(t *testing.T) {
+	s, closeFunc := newServer()
+	defer closeFunc()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/info", nil)
+	response := executeRequest(s.Router(), req)
+
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	type info struct {
+		Host             string   `json:"hostname"`
+		Address          []string `json:"address"`
+		APIServerAddress string   `json:"api_server_address"`
+		Kafka            struct {
+			BootstrapServers string   `json:"bootstrap_servers"`
+			Topics           []string `json:"topics"`
+			HistoryTopic     string   `json:"history_topic"`
+		} `json:"kafka"`
+	}
+
+	obj := info{}
+	err := json.Unmarshal(response.Body.Bytes(), &obj)
+	if err != nil {
+		t.Fatalf("unable to unmarshall json body: %v - %s", err, response.Body.Bytes())
+	}
+
+	t.Logf("info: %s", response.Body.String())
+
+	if v := obj.APIServerAddress; v != config.APIServerAddr() {
+		t.Errorf("unexpected api server address: %v", v)
+	}
+	if v := obj.Host; v == "" {
+		t.Errorf("unexpected host: %v", v)
+	}
+	if v := len(obj.Address); v == 0 {
+		t.Errorf("unexpected address length: %v", v)
+	}
+	if v := obj.Kafka.BootstrapServers; v != config.BootstrapServers() {
+		t.Errorf("unexpected kafka bootstrap servers: %v", v)
+	}
+	if v := obj.Kafka.Topics; len(v) > 0 && v[0] != "scheduler" {
+		t.Errorf("unexpected kafka topics: %v", v)
+	}
+	if v := obj.Kafka.HistoryTopic; v != "history" {
+		t.Errorf("unexpected kafka history topic: %v", v)
+	}
+}
+
+// scheduler should have an endpoint for retrieving the list of schedules planned to be scheduled in memory
+
+// Rule #3: schedules endpoint should return 404 when no schedules found
+func TestServer_schedules_notfound(t *testing.T) {
+	s, closeFunc := newServer()
+	defer closeFunc()
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/schedules", nil)
+	response := executeRequest(s.Router(), req)
+
+	checkResponseCode(t, http.StatusNotFound, response.Code)
+}
+
+// Rule #4: schedules endpoint should return 200 with schedules as payload when schedules found
+func TestServer_schedules_found(t *testing.T) {
+	s, closeFunc := newServer()
+	defer closeFunc()
+
+	now := time.Now()
+	epoch := now.Add(10 * time.Second)
+	s.Add(simple.NewSchedule("1", epoch, now))
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFunc()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/schedules", nil)
+	response := executeRequest(s.Router(), req)
+
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	type schedule struct {
+		ID        string `json:"id"`
+		Epoch     int64  `json:"epoch"`
+		Timestamp int64  `json:"timestamp"`
+	}
+
+	list := []schedule{}
+	err := json.Unmarshal(response.Body.Bytes(), &list)
+	if err != nil {
+		t.Fatalf("unable to unmarshall json body: %v - %s", err, response.Body.Bytes())
+	}
+
+	t.Logf("schedules: %s", response.Body.String())
+
+	if v := len(list); v != 1 {
+		t.Errorf("unexpected result length: %v", v)
+	}
+
+	sch := list[0]
+
+	if v := sch.ID; v != "1" {
+		t.Errorf("unexpected ID: %v", v)
+	}
+	if v := sch.Epoch; v != sch.Epoch {
+		t.Errorf("unexpected epoch: %v", v)
+	}
+	if v := sch.Timestamp; v != sch.Timestamp {
+		t.Errorf("unexpected timestamp: %v", v)
+	}
 }

--- a/internal/store/hmap/hmap.go
+++ b/internal/store/hmap/hmap.go
@@ -11,7 +11,7 @@ const (
 	eventsChanBuffer = 10000
 )
 
-// Hmap is an implementation for the store.Store interface
+// Hmap is an implementation of the store.Store interface
 type Hmap struct {
 	events chan store.Event
 }

--- a/internal/timers/timers.go
+++ b/internal/timers/timers.go
@@ -148,7 +148,7 @@ func (ts Timers) Get(id string) schedule.Schedule {
 	defer ts.mutex.RUnlock()
 
 	if t, ok := ts.items[id]; ok {
-		return t
+		return t.Schedule
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (ts Timers) GetAll() []schedule.Schedule {
 
 	result := make([]schedule.Schedule, 0)
 	for _, v := range ts.items {
-		result = append(result, v)
+		result = append(result, v.Schedule)
 	}
 	return result
 }

--- a/schedule/kafka/schedule.go
+++ b/schedule/kafka/schedule.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -32,6 +33,10 @@ func (s Schedule) TargetTopic() string {
 	return s.getHeaderValue(TargetTopic)
 }
 
+func (s Schedule) Topic() string {
+	return *s.TopicPartition.Topic
+}
+
 func (s Schedule) TargetKey() string {
 	return s.getHeaderValue(TargetKey)
 }
@@ -44,14 +49,6 @@ func (s Schedule) IsDeleted() bool {
 	return s.Value == nil
 }
 
-/*
-func (s Schedule) IsOutdated() bool {
-	if s.Epoch() < time.Now().Unix() {
-		return true
-	}
-	return false
-}
-*/
 func (s Schedule) HasErrors() []error {
 	return schedule.CheckSchedule(s)
 }
@@ -70,6 +67,19 @@ func (s Schedule) Epoch() int64 {
 		return n
 	}
 	return 0
+}
+
+func (s Schedule) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	m["id"] = s.ID()
+	m["epoch"] = s.Epoch()
+	m["timestamp"] = s.Timestamp()
+	m["topic"] = s.Topic()
+	m["target-topic"] = s.TargetTopic()
+	m["target-key"] = s.TargetKey()
+	m["value"] = s.Value
+
+	return json.Marshal(m)
 }
 
 func (s Schedule) String() string {


### PR DESCRIPTION
/info: provides scheduler's configuration (such as bootstrap servers, topics, etc ...)

/schedules: provides schedules planned for the rest of the day. It is a faithful representation
of the schedules in the memory.

Also some more changes