### PR TITLE
Add mock-server

### DIFF
--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/etf1/kafka-message-scheduler/runner/mock"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	version = "undefined"
+)
+
+func main() {
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	kafkaRunner := mock.NewRunner()
+
+	exitchan := make(chan bool)
+
+	go func() {
+		log.Printf("starting scheduler version=%v", version)
+		if err := kafkaRunner.Start(); err != nil {
+			log.Errorf("failed to start scheduler: %v", err)
+		}
+		exitchan <- true
+	}()
+
+loop:
+	for {
+		select {
+		case <-sigchan:
+			kafkaRunner.Close()
+		case <-exitchan:
+			log.Printf("scheduler exited")
+			break loop
+		}
+	}
+
+	log.Printf("exiting ...")
+}

--- a/runner/mock/handler.go
+++ b/runner/mock/handler.go
@@ -1,0 +1,17 @@
+package mock
+
+import (
+	"fmt"
+
+	"github.com/etf1/kafka-message-scheduler/scheduler"
+)
+
+type Sysout struct{}
+
+func NewHandler() Sysout {
+	return Sysout{}
+}
+
+func (s Sysout) Handle(event scheduler.Event) {
+	fmt.Printf("mock handler received event: %+v", event)
+}

--- a/runner/mock/helper_test.go
+++ b/runner/mock/helper_test.go
@@ -1,0 +1,45 @@
+package mock_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/etf1/kafka-message-scheduler/config"
+)
+
+func getInfo(timeout time.Duration) (resp *http.Response, err error) {
+	return get("/info", timeout)
+}
+
+func getSchedules(timeout time.Duration) (resp *http.Response, err error) {
+	return get("/schedules", timeout)
+}
+
+func get(path string, timeout time.Duration) (*http.Response, error) {
+	addr := os.Getenv("API_SERVER_ADDR")
+	if addr == "" {
+		addr = config.APIServerAddr()
+	}
+
+	if strings.HasPrefix(addr, ":") {
+		addr = "localhost" + addr
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+	defer cancelFunc()
+
+	url := "http://" + addr + path
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	return client.Do(req)
+}

--- a/runner/mock/mock.go
+++ b/runner/mock/mock.go
@@ -1,0 +1,77 @@
+package mock
+
+// Kafka runner for the scheduler
+
+import (
+	"time"
+
+	hmapcoll "github.com/etf1/kafka-message-scheduler/internal/collector/hmap"
+	"github.com/etf1/kafka-message-scheduler/internal/test"
+	"github.com/etf1/kafka-message-scheduler/schedule/kafka"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/etf1/kafka-message-scheduler/apiserver/rest"
+	"github.com/etf1/kafka-message-scheduler/config"
+	"github.com/etf1/kafka-message-scheduler/internal/store/hmap"
+	"github.com/etf1/kafka-message-scheduler/scheduler"
+)
+
+var (
+	Schedules = []kafka.Schedule{
+		{Message: test.FullMessage("scheduler", "schedule-1", "value 1", time.Now().Add(1*time.Hour).Unix(), "topic", "1")},
+		{Message: test.FullMessage("scheduler", "schedule-2", "value 2", time.Now().Add(1*time.Hour).Unix(), "topic", "2")},
+		{Message: test.FullMessage("scheduler", "schedule-3", "value 3", time.Now().Add(1*time.Hour).Unix(), "topic", "3")},
+	}
+)
+
+type Runner struct {
+	stopChan chan bool
+}
+
+func NewRunner() *Runner {
+	return &Runner{
+		stopChan: make(chan bool),
+	}
+}
+
+func (r Runner) Close() error {
+	r.stopChan <- true
+	return nil
+}
+
+func (r *Runner) Start() error {
+	store := hmap.New()
+
+	for _, m := range Schedules {
+		store.Add(m)
+	}
+
+	handler := NewHandler()
+
+	sch := scheduler.New(store, hmapcoll.New())
+	sch.Start(scheduler.StartOfToday())
+
+	srv := rest.New(&sch)
+	srv.Start(config.APIServerAddr())
+
+	events := sch.Events()
+
+loop:
+	for {
+		select {
+		case event, open := <-events:
+			if !open {
+				break loop
+			}
+			handler.Handle(event)
+		case <-r.stopChan:
+			err := srv.Stop()
+			if err != nil {
+				log.Errorf("error when stopping api server: %v", err)
+			}
+			sch.Close()
+		}
+	}
+
+	return nil
+}

--- a/runner/mock/mock_test.go
+++ b/runner/mock/mock_test.go
@@ -1,0 +1,143 @@
+package mock_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/etf1/kafka-message-scheduler/runner/mock"
+)
+
+// Rule #1: mock runner must expose the api server endpoint /info
+func TestMockRunner_info(t *testing.T) {
+	runner := mock.NewRunner()
+
+	exitchan := make(chan bool)
+
+	go func() {
+		if err := runner.Start(); err != nil {
+			log.Printf("failed to create the default kafka runner: %v", err)
+		}
+		exitchan <- true
+	}()
+
+	// wait for the goroutine to be scheduled
+	time.Sleep(1 * time.Second)
+
+	resp, err := getInfo(1 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	type kafka struct {
+		BootstrapServers string   `json:"bootstrap_servers"`
+		Topics           []string `json:"topics"`
+		HistoryTopic     string   `json:"history_topic"`
+	}
+	type info struct {
+		Host             string   `json:"hostname"`
+		Address          []net.IP `json:"address"`
+		APIServerAddress string   `json:"api_server_address"`
+		kafka            `json:"kafka"`
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("http response body: %s", body)
+
+	res := info{}
+	err = json.NewDecoder(bytes.NewReader(body)).Decode(&res)
+	if err != nil {
+		t.Fatalf("unable to unmarshall json body: %v %+v", err, res)
+	}
+
+	if v := res.Host; v == "" {
+		t.Fatalf("unexpected host: %v", v)
+	}
+	if v := len(res.kafka.Topics); v == 0 {
+		t.Fatalf("unexpected topics: %v", v)
+	}
+loop:
+	for {
+		select {
+		case <-time.After(2 * time.Second):
+			runner.Close()
+		case <-exitchan:
+			break loop
+		}
+	}
+}
+
+// Rule #2: mock runner must expose the api server endpoint /schedules with mocked data
+func TestMockRunner_schedules(t *testing.T) {
+	runner := mock.NewRunner()
+
+	exitchan := make(chan bool)
+
+	go func() {
+		if err := runner.Start(); err != nil {
+			log.Printf("failed to create the default kafka runner: %v", err)
+		}
+		exitchan <- true
+	}()
+
+	// wait for the goroutine to be scheduled
+	time.Sleep(1 * time.Second)
+
+	resp, err := getSchedules(1 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	type schedule struct {
+		ID          string `json:"id"`
+		Epoch       int64  `json:"epoch"`
+		Timestamp   int64  `json:"timestamp"`
+		TargetTopic string `json:"target-topic"`
+		TargetKey   string `json:"target-key"`
+		Topic       string `json:"topic"`
+		Value       []byte `json:"value"`
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("http response body: %s", body)
+
+	res := []schedule{}
+	err = json.NewDecoder(bytes.NewReader(body)).Decode(&res)
+	if err != nil {
+		t.Fatalf("unable to unmarshall json body: %v %+v", err, res)
+	}
+
+	if v := len(res); v == 0 {
+		t.Fatalf("unexpected list length: %v", v)
+	}
+loop:
+	for {
+		select {
+		case <-time.After(2 * time.Second):
+			runner.Close()
+		case <-exitchan:
+			break loop
+		}
+	}
+}


### PR DESCRIPTION
It is possible to launch a mocked version of the scheduler.
The goal is to able to use this mocked server for integration tests of the rest api.

If you are interacting with the scheduler rest api, you can use this mocked server in your integration tests.