### PR TITLE
Support nil target keys

### DIFF
--- a/runner/kafka/handler.go
+++ b/runner/kafka/handler.go
@@ -193,7 +193,7 @@ func (k EventHandler) produceTargetMessage(msg kafka.Schedule) error {
 
 	targetMsg := confluent.Message{
 		TopicPartition: confluent.TopicPartition{Topic: &targetTopic, Partition: confluent.PartitionAny},
-		Key:            []byte(msg.TargetKey()),
+		Key:            msg.TargetKey(),
 		Value:          msg.Value,
 		Headers:        headers,
 	}
@@ -205,7 +205,7 @@ func (k EventHandler) produceTargetMessage(msg kafka.Schedule) error {
 		headers: targetMsg.Headers,
 	}
 
-	log.Debugf("producing target message with id '%s' on topic '%s'", msg.TargetKey(), targetTopic)
+	log.Debugf("producing target message with id '%s' on topic '%s'", string(msg.TargetKey()), targetTopic)
 
 	return k.producer.Produce(&targetMsg, nil)
 }

--- a/schedule/kafka/schedule.go
+++ b/schedule/kafka/schedule.go
@@ -20,24 +20,24 @@ type Schedule struct {
 	*confluent.Message
 }
 
-func (s Schedule) getHeaderValue(key string) string {
+func (s Schedule) getHeaderValue(key string) []byte {
 	for i := 0; i < len(s.Headers); i++ {
-		if s.Headers[i].Key == key && len(s.Headers[i].Value) > 0 {
-			return string(s.Headers[i].Value)
+		if s.Headers[i].Key == key {
+			return s.Headers[i].Value
 		}
 	}
-	return ""
+	return nil
 }
 
 func (s Schedule) TargetTopic() string {
-	return s.getHeaderValue(TargetTopic)
+	return string(s.getHeaderValue(TargetTopic))
 }
 
 func (s Schedule) Topic() string {
 	return *s.TopicPartition.Topic
 }
 
-func (s Schedule) TargetKey() string {
+func (s Schedule) TargetKey() []byte {
 	return s.getHeaderValue(TargetKey)
 }
 
@@ -58,7 +58,7 @@ func (s Schedule) Timestamp() int64 {
 }
 
 func (s Schedule) Epoch() int64 {
-	epoch := s.getHeaderValue(Epoch)
+	epoch := string(s.getHeaderValue(Epoch))
 	if epoch != "" {
 		n, err := strconv.ParseInt(epoch, 10, 64)
 		if err != nil {
@@ -76,7 +76,7 @@ func (s Schedule) MarshalJSON() ([]byte, error) {
 	m["timestamp"] = s.Timestamp()
 	m["topic"] = s.Topic()
 	m["target-topic"] = s.TargetTopic()
-	m["target-key"] = s.TargetKey()
+	m["target-key"] = string(s.TargetKey())
 	m["value"] = s.Value
 
 	return json.Marshal(m)


### PR DESCRIPTION
Messages that are scheduled with a nil target key are currently being
inadvertently converted to messages with a zero length string target
key.

Fix the core scheduling logic so that nil values are retained.

Fixes #24 