### PR TITLE
Fix deadlock for missed events handler

### DIFF
--- a/internal/store/hmap/hmap.go
+++ b/internal/store/hmap/hmap.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	eventsChanBuffer = 10000
+	eventsChanBuffer = 1000000
 )
 
 // Hmap is an implementation of the store.Store interface
@@ -38,12 +38,21 @@ func (h Hmap) Delete(s schedule.Schedule) {
 
 // DeleteByFunc triggers the special event schedule.DeleteSchedules
 // for the specified schedule
+/*
 func (h Hmap) DeleteByFunc(s schedule.Schedule) {
 	h.events <- schedule.DeleteSchedules{
 		Time: time.Now(),
 		DeleteFunc: func(sch schedule.Schedule) bool {
 			return sch.ID() == s.ID()
 		},
+	}
+}
+*/
+
+func (h Hmap) DeleteByFunc(f func(sch schedule.Schedule) bool) {
+	h.events <- schedule.DeleteSchedules{
+		Time:       time.Now(),
+		DeleteFunc: f,
 	}
 }
 

--- a/scheduler/missed_events.go
+++ b/scheduler/missed_events.go
@@ -52,7 +52,7 @@ func (m *missedEvents) deleteByFunc(f func(s schedule.Schedule) bool) {
 
 	for _, s := range m.schedules {
 		if f(s) {
-			m.delete(s)
+			delete(m.schedules, s.ID())
 		}
 	}
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/etf1/kafka-message-scheduler/schedule"
 	"github.com/etf1/kafka-message-scheduler/schedule/simple"
 	"github.com/etf1/kafka-message-scheduler/scheduler"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -863,7 +862,6 @@ loop:
 // When scheduler is starting with processing missed events and there is a DeleteByFunc event, the scheduler
 // seems to be in a dead lock situation
 func TestScheduler_issue32(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
 	store := hmap.New()
 	coll := hmapcoll.New()
 


### PR DESCRIPTION
The problem was that we were calling a mutex Lock two times in sequence, once in DeleteByFunc and then in Delete function, so it results in a deadlock.

Fixes #32