### PR TITLE
Grace interval for outdated schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,20 @@ The scheduler is exposing metrics on a specific port (8001 by default) at the UR
 
 The scheduler can be configured with environment variables:
 
-| Env. Variable        | Default          | Description                                                                                  |
-|----------------------|------------------|----------------------------------------------------------------------------------------------|
-| `CONFIGURATION_FILE` |                  | Optional path to a YAML configuration file (see below)                                       |
-| `BOOTSTRAP_SERVERS`  | `localhost:9092` | Kafka bootstrap servers list separated by comma                                              |
-| `SCHEDULES_TOPICS`   | `schedules`      | Topic list for incoming schedules separated by comma                                         |
-| `SINCE_DELTA`        | `0`              | Number of days to go back for considering missed schedules (0:today, -1: yesterday, etc ...) |
-| `GROUP_ID`           | `scheduler-cg`   | Consumer group id for the scheduler consumer                                                 |
-| `METRICS_HTTP_ADDR`  | `:8001`          | HTTP address where prometheus metrics will be exposed (URI /metrics)                         |
-| `HISTORY_TOPIC`      | `history`        | Topic name where a copy of triggered schedules will be kept for auditing                     |
+| Env. Variable             | Default          | Description                                                                                  |
+|---------------------------|------------------|----------------------------------------------------------------------------------------------|
+| `CONFIGURATION_FILE`      |                  | Optional path to a YAML configuration file (see below)                                       |
+| `BOOTSTRAP_SERVERS`       | `localhost:9092` | Kafka bootstrap servers list separated by comma                                              |
+| `SCHEDULES_TOPICS`        | `schedules`      | Topic list for incoming schedules separated by comma                                         |
+| `SINCE_DELTA`             | `0`              | Number of days to go back for considering missed schedules (0:today, -1: yesterday, etc ...) |
+| `GROUP_ID`                | `scheduler-cg`   | Consumer group id for the scheduler consumer                                                 |
+| `METRICS_HTTP_ADDR`       | `:8001`          | HTTP address where prometheus metrics will be exposed (URI /metrics)                         |
+| `HISTORY_TOPIC`           | `history`        | Topic name where a copy of triggered schedules will be kept for auditing                     |
+| `SCHEDULE_GRACE_INTERVAL` |                  | Interval to allow schedule with outdated epoch, grace interval: now-grace_interval and now   |
+
+## Schedule grace interval
+A number of second between 0 and n, if you want to allow outdated schedules with 3s (grace interval will be between now-3s and now), then set the value
+to 3. By default the value is 0, so no grace interval.
 
 ## YAML configuration file
 

--- a/apiserver/rest/helper_test.go
+++ b/apiserver/rest/helper_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newServer() (srv rest.Server, closeFunc func()) {
-	sch := scheduler.New(hmap.New(), hmapcoll.New())
+	sch := scheduler.New(hmap.New(), hmapcoll.New(), nil)
 	sch.Start(scheduler.StartOfToday())
 
 	srv = rest.New(&sch)

--- a/apiserver/rest/server_test.go
+++ b/apiserver/rest/server_test.go
@@ -100,7 +100,10 @@ func TestServer_schedules_found(t *testing.T) {
 
 	now := time.Now()
 	epoch := now.Add(10 * time.Second)
-	s.Add(simple.NewSchedule("1", epoch, now))
+	err := s.Add(simple.NewSchedule("1", epoch, now))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
@@ -117,7 +120,7 @@ func TestServer_schedules_found(t *testing.T) {
 	}
 
 	list := []schedule{}
-	err := json.Unmarshal(response.Body.Bytes(), &list)
+	err = json.Unmarshal(response.Body.Bytes(), &list)
 	if err != nil {
 		t.Fatalf("unable to unmarshall json body: %v - %s", err, response.Body.Bytes())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -124,3 +124,7 @@ func SchedulesTopics() []string {
 func HistoryTopic() string {
 	return getString("HISTORY_TOPIC", "history")
 }
+
+func ScheduleGraceInterval() int {
+	return getInt("SCHEDULE_GRACE_INTERVAL", 0)
+}

--- a/internal/store/hmap/hmap.go
+++ b/internal/store/hmap/hmap.go
@@ -58,11 +58,11 @@ func (h Hmap) DeleteByFunc(f func(sch schedule.Schedule) bool) {
 
 func (h Hmap) Add(s schedule.Schedule) {
 	sch := s
-	errs := schedule.CheckSchedule(s)
-	if len(errs) > 0 {
+	err := schedule.CheckSchedule(s)
+	if err != nil {
 		sch = schedule.InvalidSchedule{
 			Schedule: s,
-			Errors:   errs,
+			Error:    err,
 		}
 	}
 	h.events <- sch

--- a/internal/timers/timers.go
+++ b/internal/timers/timers.go
@@ -45,17 +45,17 @@ func New() Timers {
 	return timers
 }
 
-func (ts Timers) Add(s schedule.Schedule) []error {
+func (ts Timers) Add(s schedule.Schedule) error {
 	ts.mutex.Lock()
 	defer ts.mutex.Unlock()
 
-	errors := schedule.CheckSchedule(s)
-	if len(errors) > 0 {
-		return errors
+	err := schedule.CheckSchedule(s)
+	if err != nil {
+		return err
 	}
 
 	if s.Epoch() < time.Now().Unix() {
-		return []error{fmt.Errorf("%w : %+v", schedule.ErrOutdatedScheduleEpoch, s)}
+		return fmt.Errorf("%w : %+v", schedule.ErrOutdatedScheduleEpoch, s)
 	}
 
 	// if found, we stop the existing timer

--- a/runner/kafka/handler.go
+++ b/runner/kafka/handler.go
@@ -238,7 +238,7 @@ func (k EventHandler) produceTargetMessage(msg kafka.Schedule) error {
 func (k EventHandler) Handle(event scheduler.Event) {
 	switch evt := event.(type) {
 	case schedule.InvalidSchedule:
-		log.Printf("received an InvalidSchedule event: %T %+v errors=%v", evt, evt, evt.Errors)
+		log.Printf("received an InvalidSchedule event: %T %+v error=%v", evt, evt, evt.Error)
 		// when receiving an InvalidSchedule we should delete it from the topic, so it will not be
 		// triggered if the scheduler restarts
 		msg, ok := evt.Schedule.(kafka.Schedule)

--- a/runner/kafka/runner_test.go
+++ b/runner/kafka/runner_test.go
@@ -16,12 +16,41 @@ import (
 )
 
 var (
-	fullMessage         = test.FullMessage
-	produceMessages     = test.ProduceMessages
-	createTopics        = test.CreateTopics
-	consumeMessages     = test.ConsumeMessages
-	getBootstrapServers = helper.GetDefaultBootstrapServers
+	fullMessage           = test.FullMessage
+	produceMessages       = test.ProduceMessages
+	createTopics          = test.CreateTopics
+	consumeMessages       = test.ConsumeMessages
+	assertMessagesInTopic = test.AssertMessagesinTopic
+	getBootstrapServers   = helper.GetDefaultBootstrapServers
 )
+
+type tuple struct {
+	Key   []byte
+	Value []byte
+}
+
+func checkMessagesInTopic(t *testing.T, topic string, expected []tuple) {
+	result := consumeMessages(t, topic)
+
+	if len(result) != len(expected) {
+		t.Errorf("unexpected result length: %v, expected: %v", len(result), len(expected))
+		return
+	}
+
+	for _, ve := range expected {
+		found := false
+		for _, vr := range result {
+			if bytes.Equal(ve.Key, vr.Key) && bytes.Equal(ve.Value, vr.Value) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected element not found: %+v", ve)
+			return
+		}
+	}
+}
 
 // Check the scheduler is working as expected, tombstone, history and target message should be published
 func TestDefaultKafkaRunner(t *testing.T) {
@@ -43,14 +72,15 @@ func TestDefaultKafkaRunner(t *testing.T) {
 	os.Setenv("HISTORY_TOPIC", historyTopic)
 
 	kafkaRunner := kafka.NewRunner(kafka.DefaultConfig(), kafka.DefaultSince(), hmapcoll.New())
-	exitchan := make(chan bool)
+	defer kafkaRunner.Close()
 
 	go func() {
 		if err := kafkaRunner.Start(); err != nil {
 			log.Printf("failed to create the default kafka runner: %v", err)
 		}
-		exitchan <- true
 	}()
+
+	time.Sleep(5 * time.Second)
 
 	epoch := time.Now().Add(10 * time.Second).Unix()
 	msg1 := fullMessage(schedulesTopic, scheduleKey, someValue, epoch, targetTopic, targetKey)
@@ -59,60 +89,24 @@ func TestDefaultKafkaRunner(t *testing.T) {
 	msgs := []*confluent.Message{msg1, msg2}
 
 	produceMessages(t, msgs)
-
-loop:
-	for {
-		select {
-		case <-time.After(20 * time.Second):
-			kafkaRunner.Close()
-		case <-exitchan:
-			println("break loop")
-			break loop
-		}
-	}
-
-	type tuple struct {
-		Key   []byte
-		Value []byte
-	}
-
-	checkMessage := func(topic string, expected []tuple) {
-		result := consumeMessages(t, topic)
-
-		if len(result) != len(expected) {
-			t.Fatalf("unexpected result length: %v", len(result))
-		}
-
-		for _, ve := range expected {
-			found := false
-			for _, vr := range result {
-				if bytes.Equal(ve.Key, vr.Key) && bytes.Equal(ve.Value, vr.Value) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("expected element not found: %+v", ve)
-			}
-		}
-	}
+	assertMessagesInTopic(t, schedulesTopic, msgs)
 
 	expectedMsg := []tuple{{Key: []byte(targetKey), Value: someValue}, {Key: nil, Value: someValue}}
 
 	t.Logf("check message in target topic")
 	// check messages are in the target topic
-	checkMessage(targetTopic, expectedMsg)
+	checkMessagesInTopic(t, targetTopic, expectedMsg)
 
 	t.Logf("check message in history topic")
 	// check messages are in the history topic
-	checkMessage(historyTopic, expectedMsg)
+	checkMessagesInTopic(t, historyTopic, expectedMsg)
 
 	expectedSchedules := []tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey + "2"), Value: someValue},
 		{Key: []byte(scheduleKey), Value: nil}, {Key: []byte(scheduleKey + "2"), Value: nil}}
 
 	t.Logf("check message in schedules topic")
 	// check message and tombstone message are in schedules topic
-	checkMessage(schedulesTopic, expectedSchedules)
+	checkMessagesInTopic(t, schedulesTopic, expectedSchedules)
 }
 
 // Test the relience of the multi-instance scheduler,
@@ -233,71 +227,35 @@ func TestDefaultKafkaRunner_yaml_configuration(t *testing.T) {
 	os.Setenv("HISTORY_TOPIC", historyTopic)
 
 	kafkaRunner := kafka.NewRunner(kafka.DefaultConfig(), kafka.DefaultSince(), hmapcoll.New())
-
-	exitchan := make(chan bool)
+	defer kafkaRunner.Close()
 
 	go func() {
 		if err := kafkaRunner.Start(); err != nil {
 			log.Printf("failed to create the default kafka runner: %v", err)
 		}
-		exitchan <- true
 	}()
+
+	time.Sleep(5 * time.Second)
 
 	epoch := time.Now().Add(10 * time.Second).Unix()
 	msg := fullMessage(schedulesTopic, scheduleKey, someValue, epoch, targetTopic, targetKey)
 	msgs := []*confluent.Message{msg}
 
 	produceMessages(t, msgs)
-
-loop:
-	for {
-		select {
-		case <-time.After(20 * time.Second):
-			kafkaRunner.Close()
-		case <-exitchan:
-			println("break loop")
-			break loop
-		}
-	}
-
-	type tuple struct {
-		Key   []byte
-		Value []byte
-	}
-
-	checkMessage := func(topic string, expected []tuple) {
-		result := consumeMessages(t, topic)
-
-		if len(result) != len(expected) {
-			t.Fatalf("unexpected result length: %v", len(result))
-		}
-
-		for _, ve := range expected {
-			found := false
-			for _, vr := range result {
-				if bytes.Equal(ve.Key, vr.Key) && bytes.Equal(ve.Value, vr.Value) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("expected element not found: %+v", ve)
-			}
-		}
-	}
+	assertMessagesInTopic(t, schedulesTopic, msgs)
 
 	expectedMsg := []tuple{{Key: []byte(targetKey), Value: someValue}}
 
 	// check message is in the target topic
-	checkMessage(targetTopic, expectedMsg)
+	checkMessagesInTopic(t, targetTopic, expectedMsg)
 
 	// check message is in the history topic
-	checkMessage(historyTopic, expectedMsg)
+	checkMessagesInTopic(t, historyTopic, expectedMsg)
 
 	expectedSchedules := []tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey), Value: nil}}
 
 	// check message is in the history topic
-	checkMessage(schedulesTopic, expectedSchedules)
+	checkMessagesInTopic(t, schedulesTopic, expectedSchedules)
 }
 
 // Issue #30: https://github.com/etf1/kafka-message-scheduler/issues/30
@@ -321,71 +279,129 @@ func TestDefaultKafkaRunner_issue30(t *testing.T) {
 	os.Setenv("HISTORY_TOPIC", historyTopic)
 
 	kafkaRunner := kafka.NewRunner(kafka.DefaultConfig(), kafka.DefaultSince(), hmapcoll.New())
-	exitchan := make(chan bool)
+	defer kafkaRunner.Close()
 
 	go func() {
 		if err := kafkaRunner.Start(); err != nil {
 			log.Printf("failed to create the default kafka runner: %v", err)
 		}
-		exitchan <- true
 	}()
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	epoch := time.Now().Add(-1 * time.Second).Unix()
 	msg := fullMessage(schedulesTopic, scheduleKey, someValue, epoch, targetTopic, targetKey)
 	msgs := []*confluent.Message{msg}
 
 	produceMessages(t, msgs)
-
-loop:
-	for {
-		select {
-		case <-time.After(10 * time.Second):
-			kafkaRunner.Close()
-		case <-exitchan:
-			println("break loop")
-			break loop
-		}
-	}
-
-	type tuple struct {
-		Key   []byte
-		Value []byte
-	}
-
-	checkMessage := func(topic string, expected []tuple) {
-		result := consumeMessages(t, topic)
-
-		if len(result) != len(expected) {
-			t.Fatalf("unexpected result length: %v, expected: %v", len(result), len(expected))
-		}
-
-		for _, ve := range expected {
-			found := false
-			for _, vr := range result {
-				if bytes.Equal(ve.Key, vr.Key) && bytes.Equal(ve.Value, vr.Value) {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("expected element not found: %+v", ve)
-			}
-		}
-	}
+	assertMessagesInTopic(t, schedulesTopic, msgs)
 
 	t.Logf("check message NOT in target topic")
 	// check messages are not in the target topic
-	checkMessage(targetTopic, []tuple{})
+	checkMessagesInTopic(t, targetTopic, []tuple{})
 
 	t.Logf("check message NOT in history topic")
 	// check messages are not in the history topic
-	checkMessage(historyTopic, []tuple{})
+	checkMessagesInTopic(t, historyTopic, []tuple{})
 
 	expectedSchedules := []tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey), Value: nil}}
 
 	t.Logf("check messages in schedules topic")
 	// check invalid message and tombstone message are in schedules topic because it should be deleted from the topic
-	checkMessage(schedulesTopic, expectedSchedules)
+	checkMessagesInTopic(t, schedulesTopic, expectedSchedules)
+}
+
+// Issue #31: https://github.com/etf1/kafka-message-scheduler/issues/31
+// allow grace interval for outdated schedules, for example now - 2s should be processed as valid schedule
+// the grace interval should be configurable via a env. variable
+func TestDefaultKafkaRunner_issue31(t *testing.T) {
+	someValue := []byte("some value")
+	targetKey := "target-key"
+	scheduleKey := "schedule-key"
+
+	cases := []struct {
+		graceIntervalSeconds            string // 1000, 2000, etc...
+		epochDuration                   time.Duration
+		expectedMessageInTargetTopic    []tuple
+		expectedMessageInHistoryTopic   []tuple
+		expectedMessageInSchedulesTopic []tuple
+	}{
+		{"", // by default no grace
+			0,
+			// should get a message in target topic
+			[]tuple{{Key: []byte(targetKey), Value: someValue}},
+			// also in the history topic
+			[]tuple{{Key: []byte(targetKey), Value: someValue}},
+			// in schedules topic, it should be the schedule and the tombstone for the triggered schedule
+			[]tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey), Value: nil}},
+		},
+		{"", // by default no grace
+			-1 * time.Second,
+			// should not get a message in target topic
+			[]tuple{},
+			// also not in the history topic
+			[]tuple{},
+			// in schedules topic, it should be the schedule and the tombstone for the outdated schedule
+			[]tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey), Value: nil}},
+		},
+		{"1", // grace interval between (now - 1s) and now
+			-1 * time.Second,
+			// should get a message in target topic
+			[]tuple{{Key: []byte(targetKey), Value: someValue}},
+			// also in the history topic
+			[]tuple{{Key: []byte(targetKey), Value: someValue}},
+			// in schedules topic, it should be the schedule and the tombstone for the triggered schedule
+			[]tuple{{Key: []byte(scheduleKey), Value: someValue}, {Key: []byte(scheduleKey), Value: nil}},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case #%v", i), func(t *testing.T) {
+			topics := createTopics(t, 3, []int{2, 1, 1}, "scheduler")
+
+			// scheduler topic
+			schedulesTopic := topics[0]
+			// history topic for audit
+			historyTopic := topics[1]
+			// the topic where the message should be delivered
+			targetTopic := topics[2]
+
+			if c.graceIntervalSeconds != "" {
+				os.Setenv("SCHEDULE_GRACE_INTERVAL", c.graceIntervalSeconds)
+			}
+			os.Setenv("BOOTSTRAP_SERVERS", getBootstrapServers())
+			os.Setenv("SCHEDULES_TOPICS", schedulesTopic)
+			os.Setenv("HISTORY_TOPIC", historyTopic)
+
+			kafkaRunner := kafka.NewRunner(kafka.DefaultConfig(), kafka.DefaultSince(), hmapcoll.New())
+			defer kafkaRunner.Close()
+
+			go func() {
+				if err := kafkaRunner.Start(); err != nil {
+					log.Printf("failed to create the default kafka runner: %v", err)
+				}
+			}()
+
+			time.Sleep(5 * time.Second)
+
+			epoch := time.Now().Add(c.epochDuration).Unix()
+			msg := fullMessage(schedulesTopic, scheduleKey, someValue, epoch, targetTopic, targetKey)
+			msgs := []*confluent.Message{msg}
+
+			produceMessages(t, msgs)
+			assertMessagesInTopic(t, schedulesTopic, msgs)
+
+			t.Logf("check message in target topic")
+			// check messages are in the target topic
+			checkMessagesInTopic(t, targetTopic, c.expectedMessageInTargetTopic)
+
+			t.Logf("check message in history topic")
+			// check messages are in the history topic
+			checkMessagesInTopic(t, historyTopic, c.expectedMessageInHistoryTopic)
+
+			t.Logf("check messages in schedules topic")
+			// check messages are in the schedules topic
+			checkMessagesInTopic(t, schedulesTopic, c.expectedMessageInSchedulesTopic)
+		})
+	}
 }

--- a/runner/mini/mini.go
+++ b/runner/mini/mini.go
@@ -57,7 +57,7 @@ func (r *Runner) Start() error {
 
 	handler := NewHandler(store)
 
-	sch := scheduler.New(store, hmapcoll.New())
+	sch := scheduler.New(store, hmapcoll.New(), nil)
 	sch.Start(scheduler.StartOfToday())
 
 	srv := rest.New(&sch)

--- a/schedule/helper.go
+++ b/schedule/helper.go
@@ -3,15 +3,14 @@ package schedule
 import "strings"
 
 // checks if schedule id and epoch are valid
-func CheckSchedule(s Schedule) []error {
-	result := make([]error, 0)
+func CheckSchedule(s Schedule) error {
 	if strings.TrimSpace(s.ID()) == "" {
-		result = append(result, ErrInvalidScheduleID)
+		return ErrInvalidScheduleID
 	}
 	if s.Epoch() < 0 {
-		result = append(result, ErrInvalidScheduleEpoch)
+		return ErrInvalidScheduleEpoch
 	}
-	return result
+	return nil
 }
 
 // checks if two slices of schedules are the same (order doesn't matter)

--- a/schedule/kafka/schedule.go
+++ b/schedule/kafka/schedule.go
@@ -49,7 +49,7 @@ func (s Schedule) IsDeleted() bool {
 	return s.Value == nil
 }
 
-func (s Schedule) HasErrors() []error {
+func (s Schedule) CheckSchedule() error {
 	return schedule.CheckSchedule(s)
 }
 

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -31,7 +31,7 @@ type MissedSchedule struct {
 // InvalidSchedule represents an invalid schedules (bad epoch)
 type InvalidSchedule struct {
 	Schedule
-	Errors []error
+	Error error
 }
 
 // DeletedSchedule is a deleted schedule in the store

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -70,7 +70,7 @@ func TestScheduler_trigger_epoch(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -147,7 +147,7 @@ func TestScheduler_update_epoch(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -220,7 +220,7 @@ func TestScheduler_live_schedules_not_today(t *testing.T) {
 	coll := hmapcoll.New()
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -291,7 +291,7 @@ func TestScheduler_outdated_schedule(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -368,7 +368,7 @@ func TestScheduler_ignore_invalid_schedules(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -445,7 +445,7 @@ func TestScheduler_missed_schedules_first(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -512,7 +512,7 @@ func TestScheduler_deleted_schedule(t *testing.T) {
 	store.Delete(simpleSchedule("1", 0, passed))
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -563,7 +563,7 @@ func TestScheduler_delete_schedules(t *testing.T) {
 	expected = append(expected, s1)
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -642,7 +642,7 @@ func TestScheduler_scheduler_since(t *testing.T) {
 				store.Add(schedule)
 			}
 
-			s := scheduler.New(store, coll)
+			s := scheduler.New(store, coll, nil)
 			defer s.Close()
 
 			s.Start(c.since)
@@ -698,7 +698,7 @@ func TestScheduler_collector(t *testing.T) {
 	}
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -766,7 +766,7 @@ func TestScheduler_isalive(t *testing.T) {
 	coll := hmapcoll.New()
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -821,7 +821,7 @@ func TestScheduler_issue8(t *testing.T) {
 	coll := hmapcoll.New()
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)
@@ -883,7 +883,7 @@ func TestScheduler_issue32(t *testing.T) {
 	})
 
 	startOfToday := scheduler.StartOfToday()
-	s := scheduler.New(store, coll)
+	s := scheduler.New(store, coll, nil)
 	defer s.Close()
 
 	s.Start(startOfToday)

--- a/store/kafka/store.go
+++ b/store/kafka/store.go
@@ -102,11 +102,11 @@ func (ks *Store) processMessage() {
 		sch := kafka_schedule.Schedule{
 			Message: evt,
 		}
-		errs := schedule.CheckSchedule(sch)
-		if len(errs) > 0 {
+		err := schedule.CheckSchedule(sch)
+		if err != nil {
 			ks.events <- schedule.InvalidSchedule{
 				Schedule: sch,
-				Errors:   errs,
+				Error:    err,
 			}
 			break
 		}


### PR DESCRIPTION
Sometimes you want to trigger schedules with an epoch set to now. But the message can take some time
to reach the kafka server and the scheduler. The scheduler will flag these schedules as outdated and will ignore them.
This change introduces a new configuration SCHEDULE_GRACE_INTERVAL that allows specifying a grace interval or window.

For example:
if SCHEDULE_GRACE_INTERVAL=3 and a schedule arrives with an epoch = now -1s, it will be accepted and triggered immediately.

Fixes #31 #28