### PR TITLE
Buffer stopChan and exitChan

### DIFF
--- a/runner/kafka/runner.go
+++ b/runner/kafka/runner.go
@@ -81,8 +81,8 @@ func NewRunner(c Config, since time.Time, collector instrument.Collector) *Runne
 	return &Runner{
 		config:    c,
 		since:     since,
-		stopChan:  make(chan bool),
-		exitChan:  make(chan bool),
+		stopChan:  make(chan bool, 1),
+		exitChan:  make(chan bool, 1),
 		collector: collector,
 	}
 }


### PR DESCRIPTION
The Start function has a "defer" statement that writes to exitChan to
signify that the runner has exited.  However, that write will hang if
nothing is reading from exitChan, which will happen if nobody is calling
the Close function.  This sequence of events will cause a hang:

1.  The main function starts the goroutine which calls Start.
2.  The main function continues into the "for" loop, but does not yet
    see a SIGTERM signal so it does not yet call Close.
3.  Meanwhile, the goroutine calls the Start function.
4.  The Start function fails during initialization due to any number of
    reasons, and attempts to return an error.
5.  The "defer" in Start attempts to write to exitChan as the function
    is attempting to return the error.
6.  The exitChan write hangs, because the main function has not yet
    called Close.

It's particularly problematic because:

1.  The service doesn't exit in a timely fashion due to an
    initialization error.  We should expect it to exit immediately.
2.  Because Start never returns, the initialization error is never
    logged and thus the user does not know why the service is not
    working properly.

This can be trivially fixed by buffering exitChan.  This allows the
Start function to exit immediately without hanging, and leaves the
message in the channel for Close to be able to read it later.

There is a similar issue with stopChan: if the Close function is called
before the Start function enters the "for" loop, it will again hang.
Although I think this is less likely/impossible given how the code is
currently written, it seems harmless to buffer this one as well just in
case.