### PR TITLE
Upgrade golangci-lint to v1.49.0

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM golang:alpine
 
 RUN apk update && apk add --no-cache gcc libc-dev git bash curl make
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
 RUN golangci-lint --version
 
 RUN mkdir -p /build


### PR DESCRIPTION
The older versions crash when used with the newly-released Go 1.19, which is what is currently referenced by "FROM golang:alpine".