### PR TITLE
Use incremental rebalance protocol

### DIFF
--- a/store/kafka/helper.go
+++ b/store/kafka/helper.go
@@ -8,24 +8,6 @@ func isEquals(a, b confluent.TopicPartition) bool {
 	return *a.Topic == *b.Topic && a.Partition == b.Partition
 }
 
-// returns TopicPartitions which are in arr1 and not in arr2
-func minus(arr1, arr2 confluent.TopicPartitions) confluent.TopicPartitions {
-	result := confluent.TopicPartitions{}
-	var keep bool
-	for _, a := range arr1 {
-		keep = true
-		for _, b := range arr2 {
-			if isEquals(a, b) {
-				keep = false
-			}
-		}
-		if keep {
-			result = append(result, a)
-		}
-	}
-	return result
-}
-
 // returns true if the item is in the array
 func isIn(item confluent.TopicPartition, arr confluent.TopicPartitions) bool {
 	for _, tp := range arr {

--- a/store/kafka/store.go
+++ b/store/kafka/store.go
@@ -36,8 +36,6 @@ type Store struct {
 	exitedChan    chan bool
 	resetTicker   resetTicker
 	pollTimeoutMs int
-	revoked       kafka.RevokedPartitions
-	assigned      kafka.AssignedPartitions
 }
 
 func NewStore(kafkaConfiguration kafka.ConfigMap, bootstrapServers string, topics []string, groupID string, sessionTimeout int) (*Store, error) {
@@ -52,6 +50,7 @@ func NewStore(kafkaConfiguration kafka.ConfigMap, bootstrapServers string, topic
 	finalCfg["session.timeout.ms"] = sessionTimeout
 	finalCfg["enable.auto.commit"] = false
 	finalCfg["go.events.channel.enable"] = false
+	finalCfg["partition.assignment.strategy"] = "cooperative-sticky"
 
 	consumer, err := kafka.NewConsumer(&finalCfg)
 	if err != nil {


### PR DESCRIPTION
KIP-429 adds support for incremental rebalancing of consumer groups. What this means is that the rebalance events only carry the list of partitions that were actually newly-assigned or revoked.  If a currently-assigned partition does not change status during a rebalance, then the rebalance events will no longer carry that partition.

This allows us to significantly simplify the rebalance callback:
1.  We no longer need to depend on revoke being called prior to every assign call.  This can be decoupled.
2.  The list of revoked partitions are truly the revoked ones; we don't need to worry about them being added immediately after.
3.  Similarly, we don't need to worry about assigned partitions already being active.  Any assigned partitions should always be new ones.

NOTE: Kafka doesn't support changing the type of a consumer group, so existing consumer groups using non-incremental rebalancing will need to be deleted and then recreated the new partition assignment strategy.